### PR TITLE
Fixing training crash caused by "inf"

### DIFF
--- a/histaugan/networks.py
+++ b/histaugan/networks.py
@@ -368,7 +368,7 @@ def conv3x3(in_planes, out_planes):
 def gaussian_weights_init(m):
     classname = m.__class__.__name__
     if classname.find('Conv') != -1 and classname.find('Conv') == 0:
-        torch.nn.init.normal_(m.weight, 0., 0.2)
+        torch.nn.init.normal_(m.weight, 0., 0.02)
 #     m.weight.data.normal_(0.0, 0.02)
 
 ####################################################################


### PR DESCRIPTION
Because model weights are initialised with relatively big numbers, training is crashing due to NaN error (+- inf).

Seems like a type, 0.2 should be changed to the original 0.02. 